### PR TITLE
Event loop and tray icon support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4015,6 +4015,7 @@ dependencies = [
  "log",
  "percent-encoding",
  "raw-window-handle",
+ "tao",
  "tauri",
  "tauri-runtime",
  "tauri-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ verso = { workspace = true }
 tauri = { version = "=2.5.0", default-features = false }
 tauri-runtime = "=2.6.0"
 tauri-utils = "=2.4.0"
+tao = "0.33"
 raw-window-handle = "0.6"
 url = "2"
 http = "1"

--- a/README.md
+++ b/README.md
@@ -83,6 +83,6 @@ Then go to `about:debugging` in Firefox and connect to `localhost:1234` there
 
 ## Known limitations
 
-Currently, tray icon and menu are not supported because we don't have an actuall event loop yet
+Currently, only the app wide menus on macOS are supported, per window menus are not supported yet
 
 For more, checkout the [documentation](https://versotile-org.github.io/tauri-runtime-verso/tauri_runtime_verso)

--- a/examples/api/src-tauri/Cargo.toml
+++ b/examples/api/src-tauri/Cargo.toml
@@ -14,7 +14,7 @@ tauri = { version = "2", default-features = false, features = [
     # "compression",
     "common-controls-v6",
     # Additional features
-    # "devtools",
+    "tray-icon",
 ] }
 serde_json = "1"
 log = "0.4"

--- a/examples/api/src-tauri/src/main.rs
+++ b/examples/api/src-tauri/src/main.rs
@@ -1,5 +1,7 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+mod tray;
+
 use tauri::WebviewWindowBuilder;
 use tauri_runtime_verso::{INVOKE_SYSTEM_SCRIPTS, VersoRuntime};
 
@@ -25,6 +27,7 @@ fn main() {
                 .inner_size(900., 700.)
                 .decorations(false)
                 .build()?;
+            tray::create_tray(app.handle())?;
             Ok(())
         })
         .run(tauri::generate_context!())

--- a/examples/api/src-tauri/src/tray.rs
+++ b/examples/api/src-tauri/src/tray.rs
@@ -1,21 +1,23 @@
 use tauri::{
+    AppHandle, Runtime,
     menu::{MenuBuilder, MenuItemBuilder},
     tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
 };
 
-pub fn create_tray<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> tauri::Result<()> {
+pub fn create_tray<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
     const CLICK_ME_ID: &str = "click-me";
-    let builder = MenuBuilder::new(app)
+    let menu = MenuBuilder::new(app)
         .item(
             &MenuItemBuilder::new("Click me!")
                 .id(CLICK_ME_ID)
                 .build(app)?,
         )
-        .quit();
+        .quit()
+        .build()?;
     TrayIconBuilder::new()
         .tooltip("Tauri")
         .icon(app.default_window_icon().unwrap().clone())
-        .menu(&builder.build()?)
+        .menu(&menu)
         .show_menu_on_left_click(false)
         .on_tray_icon_event(|_tray, event| match event {
             TrayIconEvent::Click {

--- a/examples/api/src-tauri/src/tray.rs
+++ b/examples/api/src-tauri/src/tray.rs
@@ -1,0 +1,37 @@
+use tauri::{
+    menu::{MenuBuilder, MenuItemBuilder},
+    tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
+};
+
+pub fn create_tray<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> tauri::Result<()> {
+    const CLICK_ME_ID: &str = "click-me";
+    let builder = MenuBuilder::new(app)
+        .item(
+            &MenuItemBuilder::new("Click me!")
+                .id(CLICK_ME_ID)
+                .build(app)?,
+        )
+        .quit();
+    TrayIconBuilder::new()
+        .tooltip("Tauri")
+        .icon(app.default_window_icon().unwrap().clone())
+        .menu(&builder.build()?)
+        .show_menu_on_left_click(false)
+        .on_tray_icon_event(|_tray, event| match event {
+            TrayIconEvent::Click {
+                button: MouseButton::Left,
+                button_state: MouseButtonState::Up,
+                ..
+            } => {
+                dbg!("Tray icon clicked!");
+            }
+            _ => {}
+        })
+        .on_menu_event(|_app, event| {
+            if event.id == CLICK_ME_ID {
+                dbg!("Click me clicked!");
+            }
+        })
+        .build(app)?;
+    Ok(())
+}

--- a/examples/helloworld/Cargo.toml
+++ b/examples/helloworld/Cargo.toml
@@ -14,7 +14,7 @@ tauri = { version = "2", default-features = false, features = [
     # "compression",
     "common-controls-v6",
     # Additional features
-    "tray-icon",
+    # "tray-icon",
 ] }
 tauri-runtime-verso = { path = "../../" }
 # serde = "1"

--- a/examples/helloworld/Cargo.toml
+++ b/examples/helloworld/Cargo.toml
@@ -14,7 +14,7 @@ tauri = { version = "2", default-features = false, features = [
     # "compression",
     "common-controls-v6",
     # Additional features
-    # "devtools",
+    "tray-icon",
 ] }
 tauri-runtime-verso = { path = "../../" }
 # serde = "1"

--- a/examples/helloworld/src/main.rs
+++ b/examples/helloworld/src/main.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-use tauri::Manager;
+use tauri::{Manager, menu::MenuBuilder};
 use tauri_runtime_verso::{INVOKE_SYSTEM_SCRIPTS, VersoRuntime};
 
 #[tauri::command]
@@ -21,10 +21,22 @@ fn main() {
         .invoke_handler(tauri::generate_handler![greet])
         .setup(|app| {
             dbg!(app.get_webview_window("main").unwrap().inner_size()).unwrap();
+            create_tray(app.handle())?;
             Ok(())
         })
         // Make sure to do this or some of the commands will not work
         .invoke_system(INVOKE_SYSTEM_SCRIPTS)
         .run(tauri::generate_context!())
         .expect("error while running tauri application")
+}
+
+fn create_tray<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> tauri::Result<()> {
+    let builder = MenuBuilder::new(app).quit();
+    tauri::tray::TrayIconBuilder::with_id("tray-1")
+        .tooltip("Tauri")
+        .icon(app.default_window_icon().unwrap().clone())
+        .menu(&builder.build()?)
+        .show_menu_on_left_click(false)
+        .build(app)?;
+    Ok(())
 }

--- a/examples/helloworld/src/main.rs
+++ b/examples/helloworld/src/main.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-use tauri::{Manager, menu::MenuBuilder};
+use tauri::Manager;
 use tauri_runtime_verso::{INVOKE_SYSTEM_SCRIPTS, VersoRuntime};
 
 #[tauri::command]
@@ -21,22 +21,10 @@ fn main() {
         .invoke_handler(tauri::generate_handler![greet])
         .setup(|app| {
             dbg!(app.get_webview_window("main").unwrap().inner_size()).unwrap();
-            create_tray(app.handle())?;
             Ok(())
         })
         // Make sure to do this or some of the commands will not work
         .invoke_system(INVOKE_SYSTEM_SCRIPTS)
         .run(tauri::generate_context!())
         .expect("error while running tauri application")
-}
-
-fn create_tray<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> tauri::Result<()> {
-    let builder = MenuBuilder::new(app).quit();
-    tauri::tray::TrayIconBuilder::with_id("tray-1")
-        .tooltip("Tauri")
-        .icon(app.default_window_icon().unwrap().clone())
-        .menu(&builder.build()?)
-        .show_menu_on_left_click(false)
-        .build(app)?;
-    Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,6 @@
 
 #![allow(unused)]
 
-use http::{Uri, uri::InvalidUri};
 use tao::{
     event::Event as TaoEvent,
     event_loop::{ControlFlow, EventLoop, EventLoopBuilder, EventLoopProxy as TaoEventLoopProxy},
@@ -108,7 +107,7 @@ use std::{
     sync::{
         Arc, Mutex, OnceLock,
         atomic::{AtomicU32, Ordering},
-        mpsc::{Receiver, SyncSender, channel, sync_channel},
+        mpsc::channel,
     },
     thread::{ThreadId, current as current_thread},
 };
@@ -510,7 +509,7 @@ fn revert_custom_protocol_work_around(
     uri: &str,
     http_or_https: &'static str,
     protocol: &str,
-) -> std::result::Result<Uri, InvalidUri> {
+) -> std::result::Result<http::Uri, http::uri::InvalidUri> {
     uri.replace(
         &format!("{http_or_https}://{protocol}."),
         &format!("{protocol}://"),


### PR DESCRIPTION
There's a known problem of creating menus in javascript will make that window stay open when the app exits, this will need a fix upstream to remove the channels when the webview closes