### PR TITLE
Update versoview and build to 0.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4569,8 +4569,8 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "verso"
-version = "0.0.2"
-source = "git+https://github.com/versotile-org/verso?rev=a3b24752b1931a5bf6feafe934cf03840511de58#a3b24752b1931a5bf6feafe934cf03840511de58"
+version = "0.0.3"
+source = "git+https://github.com/tauri-apps/verso?rev=97e9b2f220893407e02c8b54c6d747f8e13939ed#97e9b2f220893407e02c8b54c6d747f8e13939ed"
 dependencies = [
  "bincode",
  "dpi",
@@ -4586,13 +4586,13 @@ dependencies = [
 
 [[package]]
 name = "versoview_build"
-version = "0.0.2"
-source = "git+https://github.com/versotile-org/verso?rev=a3b24752b1931a5bf6feafe934cf03840511de58#a3b24752b1931a5bf6feafe934cf03840511de58"
+version = "0.0.3"
+source = "git+https://github.com/tauri-apps/verso?rev=97e9b2f220893407e02c8b54c6d747f8e13939ed#97e9b2f220893407e02c8b54c6d747f8e13939ed"
 
 [[package]]
 name = "versoview_messages"
 version = "0.0.1"
-source = "git+https://github.com/versotile-org/verso?rev=a3b24752b1931a5bf6feafe934cf03840511de58#a3b24752b1931a5bf6feafe934cf03840511de58"
+source = "git+https://github.com/tauri-apps/verso?rev=97e9b2f220893407e02c8b54c6d747f8e13939ed#97e9b2f220893407e02c8b54c6d747f8e13939ed"
 dependencies = [
  "dpi",
  "headers",
@@ -4860,7 +4860,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ members = [
 ]
 
 [workspace.dependencies]
-verso = { git = "https://github.com/versotile-org/verso", rev = "a3b24752b1931a5bf6feafe934cf03840511de58" }
-versoview_build = { git = "https://github.com/versotile-org/verso", rev = "a3b24752b1931a5bf6feafe934cf03840511de58" }
+verso = { git = "https://github.com/tauri-apps/verso", rev = "97e9b2f220893407e02c8b54c6d747f8e13939ed" }
+versoview_build = { git = "https://github.com/tauri-apps/verso", rev = "97e9b2f220893407e02c8b54c6d747f8e13939ed" }
 
 [features]
 # Required if you use tauri's macos-private-api feature
@@ -37,7 +37,7 @@ windows = "0.61"
 [target."cfg(any(target_os = \"linux\", target_os = \"dragonfly\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\"))".dependencies]
 gtk = { version = "0.18", features = ["v3_24"] }
 
-[patch."https://github.com/versotile-org/verso"]
+[patch."https://github.com/tauri-apps/verso"]
 # verso = { path = "../verso/verso" }
 # versoview_build = { path = "../verso/versoview_build" }
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ Then go to `about:debugging` in Firefox and connect to `localhost:1234` there
 
 ## Known limitations
 
+### Security
+
+We currently hard coded the `Origin` header for the custom protocol IPC to work, but this means Tauri won't be able to check for if the URL is a remote URL or a local one for the capabilities, so right now, please don't use this to load arbitrary websites if you have related settings
+
+### Menus
+
 Currently, only the app wide menus on macOS are supported, per window menus are not supported yet
 
 For more, checkout the [documentation](https://versotile-org.github.io/tauri-runtime-verso/tauri_runtime_verso)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tauri Runtime Verso
 
-A tauri runtime to replace the backend with [Verso](https://github.com/versotile-org/verso)
+A tauri runtime to replace the backend with [Verso](https://github.com/tauri-apps/verso)
 
 > Currently still working in progress
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -20,6 +20,7 @@ use tauri_runtime::{
 };
 use tauri_utils::Theme;
 use url::Url;
+use verso::CustomProtocolBuilder;
 
 use std::{
     borrow::Cow,
@@ -181,6 +182,12 @@ impl<T: UserEvent> RuntimeContext<T> {
                     .into_iter()
                     .map(|script| script.script),
             )
+            .custom_protocols(
+                pending_webview
+                    .uri_scheme_protocols
+                    .keys()
+                    .map(CustomProtocolBuilder::new),
+            )
             .build(get_verso_path(), Url::parse(&pending_webview.url).unwrap());
 
         let webview_label = label.clone();
@@ -195,9 +202,8 @@ impl<T: UserEvent> RuntimeContext<T> {
                 // dbg!(&request);
                 // TODO: Servo's EmbedderMsg::WebResourceRequested message is sent too early
                 // that it doesn't include Origin header, so I hard coded this for now
-                if !request.request.headers().contains_key("Origin") {
+                if !request.headers().contains_key("Origin") {
                     request
-                        .request
                         .headers_mut()
                         .insert("Origin", "http://tauri.localhost/".parse().unwrap());
                 }
@@ -206,14 +212,13 @@ impl<T: UserEvent> RuntimeContext<T> {
                     // we use a header instead for now
                     if scheme == "ipc" {
                         if let Some(data) = request
-                            .request
                             .headers_mut()
                             .remove("Tauri-VersoRuntime-Invoke-Body")
                         {
                             if let Ok(body) =
                                 percent_encoding::percent_decode(data.as_bytes()).decode_utf8()
                             {
-                                *request.request.body_mut() = body.as_bytes().to_vec();
+                                *request.body_mut() = body.as_bytes().to_vec();
                             } else {
                                 log::error!("IPC invoke body header is not a valid UTF-8 string");
                             }
@@ -221,7 +226,7 @@ impl<T: UserEvent> RuntimeContext<T> {
                     }
                     #[cfg(windows)]
                     let (uri, http_or_https) = (
-                        request.request.uri().to_string(),
+                        request.uri().to_string(),
                         if pending_webview.webview_attributes.use_https_scheme {
                             "https"
                         } else {
@@ -231,14 +236,14 @@ impl<T: UserEvent> RuntimeContext<T> {
                     #[cfg(windows)]
                     let is_custom_protocol_uri = is_work_around_uri(&uri, http_or_https, scheme);
                     #[cfg(not(windows))]
-                    let is_custom_protocol_uri = request.request.uri().scheme_str() == Some(scheme);
+                    let is_custom_protocol_uri = request.uri().scheme_str() == Some(scheme);
                     if is_custom_protocol_uri {
                         #[cfg(windows)]
                         {
                             if let Ok(reverted) =
                                 revert_custom_protocol_work_around(&uri, http_or_https, scheme)
                             {
-                                *request.request.uri_mut() = reverted
+                                *request.uri_mut() = reverted
                             } else {
                                 log::error!("Can't revert the URI work around on: {uri}")
                             };
@@ -249,7 +254,7 @@ impl<T: UserEvent> RuntimeContext<T> {
                         let _ = sender.send_event(Message::Task(Box::new(move || {
                             handler(
                                 &webview_label,
-                                request.request,
+                                request,
                                 Box::new(move |response| {
                                     response_fn(Some(response.map(Cow::into_owned)));
                                 }),

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -203,9 +203,18 @@ impl<T: UserEvent> RuntimeContext<T> {
                 // TODO: Servo's EmbedderMsg::WebResourceRequested message is sent too early
                 // that it doesn't include Origin header, so I hard coded this for now
                 if !request.headers().contains_key("Origin") {
-                    request
-                        .headers_mut()
-                        .insert("Origin", "http://tauri.localhost/".parse().unwrap());
+                    #[cfg(windows)]
+                    let uri = {
+                        let scheme = if pending_webview.webview_attributes.use_https_scheme {
+                            "https"
+                        } else {
+                            "http"
+                        };
+                        format!("{scheme}://tauri.localhost")
+                    };
+                    #[cfg(not(windows))]
+                    let uri = "tauri://localhost";
+                    request.headers_mut().insert("Origin", uri.parse().unwrap());
                 }
                 for (scheme, handler) in &uri_scheme_protocols {
                     // Since servo doesn't support body in its EmbedderMsg::WebResourceRequested yet,

--- a/src/webview.rs
+++ b/src/webview.rs
@@ -90,7 +90,7 @@ impl<T: UserEvent> WebviewDispatch<T> for VersoWebviewDispatcher<T> {
             .webview
             .lock()
             .unwrap()
-            .get_size()
+            .get_inner_size()
             .map_err(|_| Error::FailedToSendMessage)?;
         Ok(size)
     }
@@ -192,8 +192,12 @@ impl<T: UserEvent> WebviewDispatch<T> for VersoWebviewDispatcher<T> {
         Ok(false)
     }
 
-    /// Unsupported, has no effect when called
     fn reload(&self) -> Result<()> {
+        self.webview
+            .lock()
+            .unwrap()
+            .reload()
+            .map_err(|_| Error::FailedToSendMessage)?;
         Ok(())
     }
 


### PR DESCRIPTION
In this update:

- We now use the Verso fork at https://github.com/tauri-apps/verso
- inner/outer position/size are now properly supported
- `WebviewDispatch::reload` is now supported
- `WindowBuilder::icon` is now supported
- Custom protocols can now be accessed in secure context, this fixes #6

Also a notable change from the Servo bump is we have element highlight support in the devtools now: https://github.com/servo/servo/pull/35822
