### PR TITLE
Update local versoview on version changed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4568,7 +4568,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "verso"
 version = "0.0.4"
-source = "git+https://github.com/tauri-apps/verso?rev=aa711abbd4832a9e7a7fec8a9e7471f83b4291b1#aa711abbd4832a9e7a7fec8a9e7471f83b4291b1"
+source = "git+https://github.com/tauri-apps/verso?rev=6a9186b33462f033c0c0556235c9285f0291dc5e#6a9186b33462f033c0c0556235c9285f0291dc5e"
 dependencies = [
  "bincode",
  "dpi",
@@ -4585,12 +4585,12 @@ dependencies = [
 [[package]]
 name = "versoview_build"
 version = "0.0.4"
-source = "git+https://github.com/tauri-apps/verso?rev=aa711abbd4832a9e7a7fec8a9e7471f83b4291b1#aa711abbd4832a9e7a7fec8a9e7471f83b4291b1"
+source = "git+https://github.com/tauri-apps/verso?rev=6a9186b33462f033c0c0556235c9285f0291dc5e#6a9186b33462f033c0c0556235c9285f0291dc5e"
 
 [[package]]
 name = "versoview_messages"
 version = "0.0.1"
-source = "git+https://github.com/tauri-apps/verso?rev=aa711abbd4832a9e7a7fec8a9e7471f83b4291b1#aa711abbd4832a9e7a7fec8a9e7471f83b4291b1"
+source = "git+https://github.com/tauri-apps/verso?rev=6a9186b33462f033c0c0556235c9285f0291dc5e#6a9186b33462f033c0c0556235c9285f0291dc5e"
 dependencies = [
  "dpi",
  "headers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ members = [
 ]
 
 [workspace.dependencies]
-verso = { git = "https://github.com/tauri-apps/verso", rev = "aa711abbd4832a9e7a7fec8a9e7471f83b4291b1" }
-versoview_build = { git = "https://github.com/tauri-apps/verso", rev = "aa711abbd4832a9e7a7fec8a9e7471f83b4291b1" }
+verso = { git = "https://github.com/tauri-apps/verso", rev = "6a9186b33462f033c0c0556235c9285f0291dc5e" }
+versoview_build = { git = "https://github.com/tauri-apps/verso", rev = "6a9186b33462f033c0c0556235c9285f0291dc5e" }
 
 [features]
 # Required if you use tauri's macos-private-api feature

--- a/tauri-runtime-verso-build/src/lib.rs
+++ b/tauri-runtime-verso-build/src/lib.rs
@@ -39,8 +39,12 @@ pub fn get_verso_as_external_bin() -> io::Result<()> {
 
     let extension = if cfg!(windows) { ".exe" } else { "" };
     let output_executable = output_directory.join(format!("versoview-{target_triple}{extension}"));
+    let output_version = output_directory.join("versoview-version.txt");
 
-    if std::fs::exists(&output_executable)? {
+    if std::fs::exists(&output_executable)?
+        && std::fs::read_to_string(&output_version).unwrap_or_default()
+            == versoview_build::VERSO_VERSION
+    {
         return Ok(());
     }
 
@@ -48,8 +52,10 @@ pub fn get_verso_as_external_bin() -> io::Result<()> {
 
     let extracted_versoview_path = output_directory.join(format!("versoview{extension}"));
     std::fs::rename(extracted_versoview_path, &output_executable)?;
+    std::fs::write(&output_version, versoview_build::VERSO_VERSION)?;
 
     println!("cargo:rerun-if-changed={}", output_executable.display());
+    println!("cargo:rerun-if-changed={}", output_version.display());
 
     Ok(())
 }


### PR DESCRIPTION
Currently, we'll skip the download and decompress process in the build script if the local versoview already exists, this is fine if you don't update it, but when you do, you need to manully delete that file/directory for the build script to re-download the new version of versoview

This PR automates this process by placing a `versoview-version.txt` besides the executable file and checks if the version macthes to see if it needs an update