### PR TITLE
Update versoview and build to 0.0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4567,8 +4567,8 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "verso"
-version = "0.0.4"
-source = "git+https://github.com/tauri-apps/verso?rev=6a9186b33462f033c0c0556235c9285f0291dc5e#6a9186b33462f033c0c0556235c9285f0291dc5e"
+version = "0.0.5"
+source = "git+https://github.com/tauri-apps/verso?rev=6ba09b3418ceb6e4309159d228bcd8fdca411c89#6ba09b3418ceb6e4309159d228bcd8fdca411c89"
 dependencies = [
  "bincode",
  "dpi",
@@ -4584,13 +4584,13 @@ dependencies = [
 
 [[package]]
 name = "versoview_build"
-version = "0.0.4"
-source = "git+https://github.com/tauri-apps/verso?rev=6a9186b33462f033c0c0556235c9285f0291dc5e#6a9186b33462f033c0c0556235c9285f0291dc5e"
+version = "0.0.5"
+source = "git+https://github.com/tauri-apps/verso?rev=6ba09b3418ceb6e4309159d228bcd8fdca411c89#6ba09b3418ceb6e4309159d228bcd8fdca411c89"
 
 [[package]]
 name = "versoview_messages"
 version = "0.0.1"
-source = "git+https://github.com/tauri-apps/verso?rev=6a9186b33462f033c0c0556235c9285f0291dc5e#6a9186b33462f033c0c0556235c9285f0291dc5e"
+source = "git+https://github.com/tauri-apps/verso?rev=6ba09b3418ceb6e4309159d228bcd8fdca411c89#6ba09b3418ceb6e4309159d228bcd8fdca411c89"
 dependencies = [
  "dpi",
  "headers",
@@ -4858,7 +4858,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ members = [
 ]
 
 [workspace.dependencies]
-verso = { git = "https://github.com/tauri-apps/verso", rev = "6a9186b33462f033c0c0556235c9285f0291dc5e" }
-versoview_build = { git = "https://github.com/tauri-apps/verso", rev = "6a9186b33462f033c0c0556235c9285f0291dc5e" }
+verso = { git = "https://github.com/tauri-apps/verso", rev = "6ba09b3418ceb6e4309159d228bcd8fdca411c89" }
+versoview_build = { git = "https://github.com/tauri-apps/verso", rev = "6ba09b3418ceb6e4309159d228bcd8fdca411c89" }
 
 [features]
 # Required if you use tauri's macos-private-api feature

--- a/src/window.rs
+++ b/src/window.rs
@@ -177,13 +177,21 @@ impl WindowBuilder for VersoWindowBuilder {
         self
     }
 
-    /// Unsupported, has no effect
-    fn always_on_bottom(self, always_on_bottom: bool) -> Self {
+    fn always_on_bottom(mut self, always_on_bottom: bool) -> Self {
+        self.verso_builder = self.verso_builder.window_level(if always_on_bottom {
+            verso::WindowLevel::AlwaysOnTop
+        } else {
+            verso::WindowLevel::Normal
+        });
         self
     }
 
-    /// Unsupported, has no effect
-    fn always_on_top(self, always_on_top: bool) -> Self {
+    fn always_on_top(mut self, always_on_top: bool) -> Self {
+        self.verso_builder = self.verso_builder.window_level(if always_on_top {
+            verso::WindowLevel::AlwaysOnTop
+        } else {
+            verso::WindowLevel::Normal
+        });
         self
     }
 
@@ -479,9 +487,13 @@ impl<T: UserEvent> WindowDispatch<T> for VersoWindowDispatcher<T> {
             .map_err(|_| Error::FailedToSendMessage)
     }
 
-    /// Unsupported, always returns empty string
     fn title(&self) -> Result<String> {
-        Ok(String::new())
+        Ok(self
+            .webview
+            .lock()
+            .unwrap()
+            .get_title()
+            .map_err(|_| Error::FailedToSendMessage)?)
     }
 
     /// Unsupported, always returns [`None`]
@@ -583,8 +595,12 @@ impl<T: UserEvent> WindowDispatch<T> for VersoWindowDispatcher<T> {
         Ok(())
     }
 
-    /// Unsupported, has no effect when called
     fn set_title<S: Into<String>>(&self, title: S) -> Result<()> {
+        self.webview
+            .lock()
+            .unwrap()
+            .set_title(title)
+            .map_err(|_| Error::FailedToSendMessage)?;
         Ok(())
     }
 
@@ -662,13 +678,29 @@ impl<T: UserEvent> WindowDispatch<T> for VersoWindowDispatcher<T> {
         Ok(())
     }
 
-    /// Unsupported, has no effect when called
     fn set_always_on_bottom(&self, always_on_bottom: bool) -> Result<()> {
+        self.webview
+            .lock()
+            .unwrap()
+            .set_window_level(if always_on_bottom {
+                verso::WindowLevel::AlwaysOnBottom
+            } else {
+                verso::WindowLevel::Normal
+            })
+            .map_err(|_| Error::FailedToSendMessage)?;
         Ok(())
     }
 
-    /// Unsupported, has no effect when called
     fn set_always_on_top(&self, always_on_top: bool) -> Result<()> {
+        self.webview
+            .lock()
+            .unwrap()
+            .set_window_level(if always_on_top {
+                verso::WindowLevel::AlwaysOnTop
+            } else {
+                verso::WindowLevel::Normal
+            })
+            .map_err(|_| Error::FailedToSendMessage)?;
         Ok(())
     }
 


### PR DESCRIPTION
The following APIs are now supported

- `WindowBuilder::always_on_bottom`
- `WindowBuilder::always_on_top`
- `WindowDispatch::always_on_bottom`
- `WindowDispatch::always_on_top`
- `WindowDispatch::set_title`
- `WindowDispatch::title`
